### PR TITLE
add XPU tuning to JSD

### DIFF
--- a/src/liger_kernel/ops/jsd.py
+++ b/src/liger_kernel/ops/jsd.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 
 from liger_kernel.ops.utils import ensure_contiguous
-
+from liger_kernel.utils import infer_device
 
 @triton.jit
 def _jsd_kernel(
@@ -92,7 +92,7 @@ def _jsd_kernel(
         tl.store(dX_ptr + offsets, dX, mask=mask)
 
 
-MAX_FUSED_SIZE = 65536
+MAX_FUSED_SIZE = 4096 if infer_device() == "xpu" else 65536
 
 
 def jsd_forward(_input, target, shift_labels, beta, ignore_index, has_label):


### PR DESCRIPTION
## Summary
Tuning on XPU: In JSD, if device is XPU, set MAX_FUSED_SIZE to 4096 instead of default 65536. This gives slightly better performance on XPU.

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Intel(R) Data Center GPU Max 1550
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
